### PR TITLE
fix: Update pprof dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -687,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632d02bff7f874a36f33ea8bb416cd484b90cc66c1194b1a1110d067a7013f58"
+checksum = "a1feb54ed693b93a84e14094943b84b7c4eae204c512b7ccb95ab0c66d278ad1"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,9 +320,9 @@ dependencies = [
 
 [[package]]
 name = "inferno"
-version = "0.10.12"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3886428c6400486522cf44b8626e7b94ad794c14390290f2a274dcf728a58f"
+checksum = "f202af59e95fce985d0b87df19319528638b6f7654abc283d2815028922cc320"
 dependencies = [
  "ahash",
  "atty",
@@ -523,27 +523,25 @@ checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
- "instant",
  "lock_api",
  "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
- "instant",
  "libc",
  "redox_syscall",
  "smallvec",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -564,22 +562,23 @@ dependencies = [
 
 [[package]]
 name = "pprof"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f35f865aa964be21fcde114cbd1cfbd9bf8a471460ed965b0f84f96c711401"
+checksum = "c090facb9ab04a4fb15fe27f8861059f195dd0847e6f1042016244e129eddeb2"
 dependencies = [
  "backtrace",
  "cfg-if",
  "findshlibs",
  "inferno",
- "lazy_static",
  "libc",
  "log",
  "nix",
+ "once_cell",
  "parking_lot",
  "prost 0.9.0",
  "prost-build",
  "prost-derive 0.9.0",
+ "protobuf",
  "smallvec",
  "symbolic-demangle",
  "tempfile",
@@ -670,6 +669,12 @@ dependencies = [
  "bytes",
  "prost 0.9.0",
 ]
+
+[[package]]
+name = "protobuf"
+version = "2.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "quick-xml"
@@ -933,3 +938,46 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+dependencies = [
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ backtrace = "0.3.65"
 bytes = "1.1.0"
 lazy_static = "1.4.0"
 libc = { version = "^0.2.124", default-features = false }
-pprof = {version = "^0.6", features = [ "flamegraph", "protobuf" ] }
+pprof = {version = "^0.7", features = [ "prost-codec", "flamegraph", "protobuf" ] }
 spin = "0.9.3"
 tikv-jemalloc-sys = { version = "0.4", optional = true, features = [ "stats" ] }
 thiserror = "^1"

--- a/src/profiler.rs
+++ b/src/profiler.rs
@@ -293,37 +293,37 @@ impl HeapReport {
 
         let sample_type = vec![
             protos::ValueType {
-                r#type: alloc_objects_idx,
+                ty: alloc_objects_idx,
                 unit: count_idx,
             },
             protos::ValueType {
-                r#type: alloc_space_idx,
+                ty: alloc_space_idx,
                 unit: bytes_idx,
             },
             #[cfg(feature = "measure_free")]
             protos::ValueType {
-                r#type: free_objects_idx,
+                ty: free_objects_idx,
                 unit: count_idx,
             },
             #[cfg(feature = "measure_free")]
             protos::ValueType {
-                r#type: free_space_idx,
+                ty: free_space_idx,
                 unit: count_idx,
             },
             #[cfg(feature = "measure_free")]
             protos::ValueType {
-                r#type: inuse_objects_idx,
+                ty: inuse_objects_idx,
                 unit: count_idx,
             },
             #[cfg(feature = "measure_free")]
             protos::ValueType {
-                r#type: inuse_space_idx,
+                ty: inuse_space_idx,
                 unit: bytes_idx,
             },
         ];
 
         let period_type = Some(pprof::protos::ValueType {
-            r#type: space_idx,
+            ty: space_idx,
             unit: bytes_idx,
         });
 


### PR DESCRIPTION

The old version of pprof (and thus old versions of tonoc / prost / etc) is still built and bundled with heappy and thus IOx. Update to latest pprof to get latest and greatest tonic / prost, and thus also 

re https://github.com/influxdata/influxdb_iox/pull/4357
