### PR TITLE
chore: add license to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "heappy"
 version = "0.1.0"
 authors = [ "Marko Mikulicic <mkm@influxdata.com>" ]
 edition = "2021"
+license = "Apache-2.0"
 
 [workspace]
 members = [


### PR DESCRIPTION
Currently `heappy` is failing our internal licence checker because the license field is missing.